### PR TITLE
Devops 997 add kaniko go builds

### DIFF
--- a/.github/workflows/goreleaser-build.yaml
+++ b/.github/workflows/goreleaser-build.yaml
@@ -34,7 +34,7 @@ on:
 jobs:
   build:
     runs-on: self-hosted
-    name: Build/Push
+    name: Build
     steps:
       - name: checkout git
         uses: actions/checkout@v3
@@ -62,7 +62,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
           GOVERSION: ${{ steps.go_version.outputs.GO_VERSION }}
-          REGISTRY: ${{ env.ARTIFACT_REGISTRY }}
+          REGISTRY: ${{ inputs.GCP_ARTIFACT_REPO }}
 
       - name: Docker push
         if: github.event_name == 'push'

--- a/.github/workflows/goreleaser-build.yaml
+++ b/.github/workflows/goreleaser-build.yaml
@@ -65,7 +65,7 @@ jobs:
           REGISTRY: ${{ inputs.GCP_ARTIFACT_REPO }}
 
       - name: Docker push
-        if: ${{ github.event_name == 'push' || github.event_name == 'publish' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
         run: |
           PROJECT_NAME=$(cat .goreleaser.yml | grep project_name | awk '{print $2}')
           IMAGE=$(docker image ls | grep $PROJECT_NAME | grep ${{ inputs.APP_VERSION }} | awk '{print $1}')

--- a/.github/workflows/goreleaser-build.yaml
+++ b/.github/workflows/goreleaser-build.yaml
@@ -65,7 +65,7 @@ jobs:
           REGISTRY: ${{ inputs.GCP_ARTIFACT_REPO }}
 
       - name: Docker push
-        if: github.event_name == 'push'
+        if: ${{ github.event_name == 'push' || github.event_name == 'publish' }}
         run: |
           PROJECT_NAME=$(cat .goreleaser.yml | grep project_name | awk '{print $2}')
           IMAGE=$(docker image ls | grep $PROJECT_NAME | grep ${{ inputs.APP_VERSION }} | awk '{print $1}')

--- a/.github/workflows/goreleaser-build.yaml
+++ b/.github/workflows/goreleaser-build.yaml
@@ -1,0 +1,72 @@
+name: GoReleaser Build
+
+on:
+  workflow_call:
+    inputs:
+
+      # GCP Artifact Repository URL for container images
+      GCP_ARTIFACT_REPO:
+        required: false
+        type: string
+        default: 'us-central1-docker.pkg.dev/cyderes-dev/cyderes-container-repo'
+
+      # Artifact Registry repositories to push to
+      ARTIFACT_REGISTRY:
+        required: false
+        type: string
+        default: us-central1-docker.pkg.dev
+
+      # Artifact Registry repositories to push to
+      APP_VERSION:
+        required: false
+        type: string
+        default: latest
+
+      # Credentials to use for GCP Artifact Registry. Should be secrets available to calling workflow project.
+    secrets:
+      GCP_ARGO_SERVICE_ACCOUNT:
+        required: true
+
+      # GitHub service account token used for GitHub NPM registry
+      CI_GITHUB_TOKEN:
+        required: true
+
+jobs:
+  build:
+    runs-on: self-hosted
+    name: Build/Push
+    steps:
+      - name: checkout git
+        uses: actions/checkout@v3
+
+      - uses: 'docker/login-action@v1'
+        with:
+          registry: ${{ inputs.ARTIFACT_REGISTRY }}
+          username: _json_key_base64
+          password: ${{ secrets.GCP_ARGO_SERVICE_ACCOUNT }}
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '^1.13.1'
+
+      - name: Get Go version
+        id: go_version
+        run: echo ::set-output name=GO_VERSION::$(go version | awk '{print $3}')
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --snapshot --rm-dist --skip-sign --debug
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+          GOVERSION: ${{ steps.go_version.outputs.GO_VERSION }}
+          REGISTRY: ${{ env.ARTIFACT_REGISTRY }}
+
+      - name: Docker push
+        if: github.event_name == 'push'
+        run: |
+          PROJECT_NAME=$(cat .goreleaser.yml | grep project_name | awk '{print $2}')
+          IMAGE=$(docker image ls | grep $PROJECT_NAME | grep ${{ inputs.APP_VERSION }} | awk '{print $1}')
+          docker push ${IMAGE}:${{ inputs.APP_VERSION }}

--- a/.github/workflows/goreleaser-build.yaml
+++ b/.github/workflows/goreleaser-build.yaml
@@ -9,19 +9,19 @@ on:
         required: false
         type: string
 
-      # Artifact Registry repositories to push to
+      # Artifact Registry host/region
       ARTIFACT_REGISTRY_HOST:
         required: false
         type: string
         default: us-central1-docker.pkg.dev
 
-      # Artifact Registry repositories to push to
+      # Artifact Registry repository
       ARTIFACT_REGISTRY_REPO:
         required: false
         type: string
         default: cyderes-container-repo
 
-      # Artifact Registry repositories to push to
+      # Version tag to use when pushing to Production repository
       APP_VERSION:
         required: false
         type: string

--- a/.github/workflows/goreleaser-build.yaml
+++ b/.github/workflows/goreleaser-build.yaml
@@ -85,6 +85,6 @@ jobs:
         run: |
           PROJECT_NAME=$(cat .goreleaser.yml | grep project_name | awk '{print $2}')
           SOURCE_IMAGE=$(docker image ls | grep $PROJECT_NAME | grep ${{ inputs.APP_VERSION }} | awk '{print $1}')
-          TARGET_IMAGE="${{ inputs.ARTIFACT_REGISTRY_HOST }}/${{ steps.set_env.outputs.GCP_PROJECT }}/${{ inputs.ARTIFACT_REGISTRY_REPO }}/${PROJECT_NAME}:${{ inputs.APP_VERSION }}""
+          TARGET_IMAGE="${{ inputs.ARTIFACT_REGISTRY_HOST }}/${{ steps.set_env.outputs.GCP_PROJECT }}/${{ inputs.ARTIFACT_REGISTRY_REPO }}/${PROJECT_NAME}:${{ inputs.APP_VERSION }}"
           docker image tag ${SOURCE_IMAGE} ${TARGET_IMAGE}
           docker push ${TARGET_IMAGE}

--- a/.github/workflows/goreleaser-build.yaml
+++ b/.github/workflows/goreleaser-build.yaml
@@ -48,11 +48,11 @@ jobs:
         id: set_env
         run: |
           if [[ -n "${{ inputs.GCP_PROJECT }}" ]]; then
-            echo ::set-output name=GCP_PROJECT::${{ inputs.GCP_PROJECT }})
+            echo ::set-output name=GCP_PROJECT::${{ inputs.GCP_PROJECT }}
           elif [[ "${{ github.event_name }}" =~ (^release$) ]]; then
-            echo ::set-output name=GCP_PROJECT::cyderes-prod)
+            echo ::set-output name=GCP_PROJECT::cyderes-prod
           else
-            echo ::set-output name=GCP_PROJECT::cyderes-dev)
+            echo ::set-output name=GCP_PROJECT::cyderes-dev
           fi
 
       - uses: 'docker/login-action@v1'

--- a/.github/workflows/goreleaser-build.yaml
+++ b/.github/workflows/goreleaser-build.yaml
@@ -34,7 +34,7 @@ on:
 
       # GitHub service account token used for GitHub NPM registry
       CI_GITHUB_TOKEN:
-        required: false
+        required: true
 
 jobs:
   build:

--- a/.github/workflows/goreleaser-build.yaml
+++ b/.github/workflows/goreleaser-build.yaml
@@ -34,7 +34,7 @@ on:
 
       # GitHub service account token used for GitHub NPM registry
       CI_GITHUB_TOKEN:
-        required: true
+        required: false
 
 jobs:
   build:

--- a/.github/workflows/goreleaser-build.yaml
+++ b/.github/workflows/goreleaser-build.yaml
@@ -28,13 +28,14 @@ on:
         default: latest
 
       # Credentials to use for GCP Artifact Registry. Should be secrets available to calling workflow project.
-    secrets:
-      GCP_ARGO_SERVICE_ACCOUNT:
-        required: true
+    secrets: inherit
+    
+      # GCP_ARGO_SERVICE_ACCOUNT:
+      #   required: true
 
-      # GitHub service account token used for GitHub NPM registry
-      CI_GITHUB_TOKEN:
-        required: true
+      # # GitHub service account token used for GitHub NPM registry
+      # CI_GITHUB_TOKEN:
+      #   required: true
 
 jobs:
   build:
@@ -55,7 +56,17 @@ jobs:
             echo ::set-output name=GCP_PROJECT::cyderes-dev
           fi
 
-      - uses: 'docker/login-action@v1'
+      - name: Docker login (Dev)
+        uses: 'docker/login-action@v1'
+        if: ${{ github.event_name != 'release' }}
+        with:
+          registry: ${{ inputs.ARTIFACT_REGISTRY_HOST }}
+          username: _json_key_base64
+          password: ${{ secrets.GCP_ARGO_SERVICE_ACCOUNT_DEV }}
+
+      - name: Docker login (Prod)
+        uses: 'docker/login-action@v1'
+        if: ${{ github.event_name == 'release' }}
         with:
           registry: ${{ inputs.ARTIFACT_REGISTRY_HOST }}
           username: _json_key_base64

--- a/.github/workflows/goreleaser-build.yaml
+++ b/.github/workflows/goreleaser-build.yaml
@@ -4,17 +4,22 @@ on:
   workflow_call:
     inputs:
 
-      # GCP Artifact Repository URL for container images
-      GCP_ARTIFACT_REGISTRY:
+      # GCP Project containing Artifact Registry repository
+      GCP_PROJECT:
         required: false
         type: string
-        default: 'us-central1-docker.pkg.dev/cyderes-dev/cyderes-container-repo'
 
       # Artifact Registry repositories to push to
       ARTIFACT_REGISTRY_HOST:
         required: false
         type: string
         default: us-central1-docker.pkg.dev
+
+      # Artifact Registry repositories to push to
+      ARTIFACT_REGISTRY_REPO:
+        required: false
+        type: string
+        default: cyderes-container-repo
 
       # Artifact Registry repositories to push to
       APP_VERSION:
@@ -38,6 +43,17 @@ jobs:
     steps:
       - name: checkout git
         uses: actions/checkout@v3
+
+      - name: Set environment
+        id: set_env
+        run: |
+          if [[ -n "${{ inputs.GCP_PROJECT }}" ]]; then
+            echo ::set-output name=GCP_PROJECT::${{ inputs.GCP_PROJECT }})
+          elif [[ "${{ github.event_name }}" =~ (^release$) ]]; then
+            echo ::set-output name=GCP_PROJECT::cyderes-prod)
+          else
+            echo ::set-output name=GCP_PROJECT::cyderes-dev)
+          fi
 
       - uses: 'docker/login-action@v1'
         with:
@@ -68,6 +84,7 @@ jobs:
         if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
         run: |
           PROJECT_NAME=$(cat .goreleaser.yml | grep project_name | awk '{print $2}')
-          IMAGE=$(docker image ls | grep $PROJECT_NAME | grep ${{ inputs.APP_VERSION }} | awk '{print $1}')
-          docker image tag ${IMAGE} ${{ inputs.GCP_ARTIFACT_REPO}}/${PROJECT_NAME}:${{ inputs.APP_VERSION }}
-          docker push ${{ inputs.GCP_ARTIFACT_REPO}}/${PROJECT_NAME}:${{ inputs.APP_VERSION }}
+          SOURCE_IMAGE=$(docker image ls | grep $PROJECT_NAME | grep ${{ inputs.APP_VERSION }} | awk '{print $1}')
+          TARGET_IMAGE="${{ inputs.ARTIFACT_REGISTRY_HOST }}/${{ steps.set_env.outputs.GCP_PROJECT }}/${{ inputs.ARTIFACT_REGISTRY_REPO }}/${PROJECT_NAME}:${{ inputs.APP_VERSION }}""
+          docker image tag ${SOURCE_IMAGE} ${TARGET_IMAGE}
+          docker push ${TARGET_IMAGE}

--- a/.github/workflows/goreleaser-build.yaml
+++ b/.github/workflows/goreleaser-build.yaml
@@ -78,7 +78,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
           GOVERSION: ${{ steps.go_version.outputs.GO_VERSION }}
-          REGISTRY: ${{ inputs.GCP_ARTIFACT_REPO }}
+          REGISTRY: ${{ inputs.ARTIFACT_REGISTRY_HOST }}/${{ steps.set_env.outputs.GCP_PROJECT }}/${{ inputs.ARTIFACT_REGISTRY_REPO }}
 
       - name: Docker push
         if: ${{ github.event_name == 'push' || github.event_name == 'release' }}

--- a/.github/workflows/goreleaser-build.yaml
+++ b/.github/workflows/goreleaser-build.yaml
@@ -69,4 +69,5 @@ jobs:
         run: |
           PROJECT_NAME=$(cat .goreleaser.yml | grep project_name | awk '{print $2}')
           IMAGE=$(docker image ls | grep $PROJECT_NAME | grep ${{ inputs.APP_VERSION }} | awk '{print $1}')
-          docker push ${IMAGE}:${{ inputs.APP_VERSION }}
+          docker image tag ${IMAGE} ${{ inputs.GCP_ARTIFACT_REPO}}/${PROJECT_NAME}:${{ inputs.APP_VERSION }}
+          docker push ${{ inputs.GCP_ARTIFACT_REPO}}/${PROJECT_NAME}:${{ inputs.APP_VERSION }}

--- a/.github/workflows/goreleaser-build.yaml
+++ b/.github/workflows/goreleaser-build.yaml
@@ -27,16 +27,6 @@ on:
         type: string
         default: latest
 
-      # Credentials to use for GCP Artifact Registry. Should be secrets available to calling workflow project.
-    secrets: inherit
-    
-      # GCP_ARGO_SERVICE_ACCOUNT:
-      #   required: true
-
-      # # GitHub service account token used for GitHub NPM registry
-      # CI_GITHUB_TOKEN:
-      #   required: true
-
 jobs:
   build:
     runs-on: self-hosted

--- a/.github/workflows/goreleaser-build.yaml
+++ b/.github/workflows/goreleaser-build.yaml
@@ -5,13 +5,13 @@ on:
     inputs:
 
       # GCP Artifact Repository URL for container images
-      GCP_ARTIFACT_REPO:
+      GCP_ARTIFACT_REGISTRY:
         required: false
         type: string
         default: 'us-central1-docker.pkg.dev/cyderes-dev/cyderes-container-repo'
 
       # Artifact Registry repositories to push to
-      ARTIFACT_REGISTRY:
+      ARTIFACT_REGISTRY_HOST:
         required: false
         type: string
         default: us-central1-docker.pkg.dev
@@ -41,7 +41,7 @@ jobs:
 
       - uses: 'docker/login-action@v1'
         with:
-          registry: ${{ inputs.ARTIFACT_REGISTRY }}
+          registry: ${{ inputs.ARTIFACT_REGISTRY_HOST }}
           username: _json_key_base64
           password: ${{ secrets.GCP_ARGO_SERVICE_ACCOUNT }}
 


### PR DESCRIPTION
## Please ensure you've completed the following:
- [x] I have ensured my commit(s) adhere to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added relevant tests and/or examples for my code
- [ ] I have made corresponding changes to the documentation

## What are you changing?
- Adding `goreleaser-build.yaml` reusable workflow

## What is the reasoning for the change?
- Support Golang project builds

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
- `comment here`


## Other information:

