### PR TITLE
chore: update action kaniko to 0.10.0

### DIFF
--- a/.github/workflows/kaniko-build-generic.yaml
+++ b/.github/workflows/kaniko-build-generic.yaml
@@ -102,7 +102,7 @@ jobs:
           fi
 
       - name: Kaniko build
-        uses: aevea/action-kaniko@v0.9.0
+        uses: aevea/action-kaniko@v0.10.0
         with:
           image: ${{ inputs.IMAGE }}
           registry: ${{ inputs.ARTIFACT_REGISTRY_HOST }}/${{ steps.set_env.outputs.GCP_PROJECT }}/${{ inputs.ARTIFACT_REGISTRY_REPO }}

--- a/.github/workflows/kaniko-build-node.yaml
+++ b/.github/workflows/kaniko-build-node.yaml
@@ -140,7 +140,7 @@ jobs:
         run: cd ${{ inputs.CONTEXT_PATH }}; npm run lint
 
       - name: Kaniko build
-        uses: aevea/action-kaniko@v0.9.0
+        uses: aevea/action-kaniko@v0.10.0
         with:
           image: ${{ inputs.IMAGE }}
           registry: ${{ inputs.ARTIFACT_REGISTRY_HOST }}/${{ steps.set_env.outputs.GCP_PROJECT }}/${{ inputs.ARTIFACT_REGISTRY_REPO }}

--- a/.github/workflows/kaniko-push-generic.yaml
+++ b/.github/workflows/kaniko-push-generic.yaml
@@ -53,7 +53,7 @@ jobs:
         run: env
 
       - name: Kaniko build and push
-        uses: aevea/action-kaniko@v0.9.0
+        uses: aevea/action-kaniko@v0.10.0
         with:
           image: ${{ inputs.IMAGE }}
           registry: ${{ inputs.GCP_ARTIFACT_REGISTRY }}

--- a/.github/workflows/kaniko-push-node.yaml
+++ b/.github/workflows/kaniko-push-node.yaml
@@ -68,7 +68,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
 
       - name: Kaniko build and push
-        uses: aevea/action-kaniko@v0.9.0
+        uses: aevea/action-kaniko@v0.10.0
         with:
           image: ${{ inputs.IMAGE }}
           registry: ${{ inputs.GCP_ARTIFACT_REGISTRY }}


### PR DESCRIPTION
## What are you changing?

`Updating Kaniko action templates to use latest release 0.10.0`


## What is the reasoning for the change?

`Resolve an issue where a layer was being corrupted and couldn't find files in the node_modules/storybook directory`
`See this issue for more info: https://github.com/aevea/action-kaniko/pull/40#issuecomment-1366154378`


## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

`No`


## Other information - TODO:


## CheckList:
- [x] I have ensured my commit(s) adhere to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have performed a self-review of my code changes.
- [ ] I have commented my code, particularly in hard-to-understand areas. (if applicable)
- [ ] I have added relevant tests and/or examples for my code. (if applicable)
- [ ] I have made corresponding changes to the documentation. (if applicable)


### semantic PR types:
- feat
- fix
- docs
- style
- refactor
- perf
- test
- build
- ci
- chore
- revert
